### PR TITLE
Add SAQ Type Selection Dropdown to iOS Frontend

### DIFF
--- a/APUSHGrader/Models/APIModels.swift
+++ b/APUSHGrader/Models/APIModels.swift
@@ -53,6 +53,36 @@ enum EssayType: String, CaseIterable {
     }
 }
 
+// MARK: - SAQ Type
+
+enum SAQType: String, CaseIterable {
+    case stimulus = "stimulus"
+    case nonStimulus = "non_stimulus"
+    case secondaryComparison = "secondary_comparison"
+    
+    var displayName: String {
+        switch self {
+        case .stimulus:
+            return "Source Analysis"
+        case .nonStimulus:
+            return "Content Question"
+        case .secondaryComparison:
+            return "Historical Comparison"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .stimulus:
+            return "Analyzes primary or secondary source documents"
+        case .nonStimulus:
+            return "Tests historical content knowledge without sources"
+        case .secondaryComparison:
+            return "Compares different historical interpretations"
+        }
+    }
+}
+
 // MARK: - SAQ Multi-Part Support
 
 struct SAQParts: Codable {

--- a/APUSHGrader/Services/NetworkService.swift
+++ b/APUSHGrader/Services/NetworkService.swift
@@ -7,28 +7,32 @@ struct GradingRequest: Codable {
     let essayType: String
     let prompt: String
     let saqParts: SAQParts?
+    let saqType: String?
     
     enum CodingKeys: String, CodingKey {
         case essayText = "essay_text"
         case essayType = "essay_type"
         case prompt
         case saqParts = "saq_parts"
+        case saqType = "saq_type"
     }
     
     // Legacy initializer for DBQ/LEQ
-    init(essayText: String, essayType: String, prompt: String) {
+    init(essayText: String, essayType: String, prompt: String, saqType: String? = nil) {
         self.essayText = essayText
         self.essayType = essayType
         self.prompt = prompt
         self.saqParts = nil
+        self.saqType = saqType
     }
     
     // New initializer for SAQ with parts
-    init(saqParts: SAQParts, essayType: String, prompt: String) {
+    init(saqParts: SAQParts, essayType: String, prompt: String, saqType: String? = nil) {
         self.essayText = ""  // Backend will use saq_parts instead
         self.essayType = essayType
         self.prompt = prompt
         self.saqParts = saqParts
+        self.saqType = saqType
     }
 }
 
@@ -136,7 +140,8 @@ class NetworkService {
     func gradeEssay(
         essayText: String,
         essayType: String,
-        prompt: String
+        prompt: String,
+        saqType: String? = nil
     ) async throws -> GradingResponse {
         
         guard let url = URL(string: "\(baseURL)/api/v1/grade") else {
@@ -146,7 +151,8 @@ class NetworkService {
         let request = GradingRequest(
             essayText: essayText,
             essayType: essayType,
-            prompt: prompt
+            prompt: prompt,
+            saqType: saqType
         )
         
         var urlRequest = URLRequest(url: url)
@@ -224,7 +230,8 @@ class NetworkService {
     func gradeEssayWithSAQParts(
         saqParts: SAQParts,
         essayType: String,
-        prompt: String
+        prompt: String,
+        saqType: String? = nil
     ) async throws -> GradingResponse {
         
         guard let url = URL(string: "\(baseURL)/api/v1/grade") else {
@@ -234,7 +241,8 @@ class NetworkService {
         let request = GradingRequest(
             saqParts: saqParts,
             essayType: essayType,
-            prompt: prompt
+            prompt: prompt,
+            saqType: saqType
         )
         
         var urlRequest = URLRequest(url: url)

--- a/APUSHGrader/Views/Main/ContentView.swift
+++ b/APUSHGrader/Views/Main/ContentView.swift
@@ -14,6 +14,7 @@ struct ContentView: View {
     @State private var saqPartA: String = ""
     @State private var saqPartB: String = ""
     @State private var saqPartC: String = ""
+    @State private var saqType: SAQType? = nil
     
     private let networkService = NetworkService.shared
     
@@ -35,6 +36,10 @@ struct ContentView: View {
                         .onChange(of: essayType) { _, _ in
                             clearFields()
                         }
+                    
+                    if essayType == .saq {
+                        SAQTypeSelector(selectedType: $saqType)
+                    }
                     
                     PromptInputView(text: $promptText, essayType: essayType)
                     
@@ -88,13 +93,15 @@ struct ContentView: View {
                     response = try await networkService.gradeEssayWithSAQParts(
                         saqParts: saqParts,
                         essayType: essayType.rawValue,
-                        prompt: promptText
+                        prompt: promptText,
+                        saqType: saqType?.rawValue
                     )
                 } else {
                     response = try await networkService.gradeEssay(
                         essayText: essayText,
                         essayType: essayType.rawValue,
-                        prompt: promptText
+                        prompt: promptText,
+                        saqType: saqType?.rawValue
                     )
                 }
                 
@@ -132,6 +139,7 @@ struct ContentView: View {
         saqPartA = ""
         saqPartB = ""
         saqPartC = ""
+        saqType = nil
         promptText = ""
         processedResult = nil
     }
@@ -235,6 +243,40 @@ private struct SAQMultiPartInputView: View {
         .background(Color(.systemBackground))
         .cornerRadius(12)
         .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - SAQ Type Selector Component
+
+private struct SAQTypeSelector: View {
+    @Binding var selectedType: SAQType?
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("SAQ Type (Optional)")
+                .font(.headline)
+            
+            Picker("SAQ Type", selection: $selectedType) {
+                Text("Not Selected").tag(nil as SAQType?)
+                
+                ForEach(SAQType.allCases, id: \.self) { type in
+                    Text(type.displayName).tag(type as SAQType?)
+                }
+            }
+            .pickerStyle(MenuPickerStyle())
+            .frame(maxWidth: .infinity, alignment: .leading)
+            
+            if let selectedType = selectedType {
+                Text(selectedType.description)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("Choose the type of SAQ for more accurate grading")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
         .padding(.horizontal)
     }
 }


### PR DESCRIPTION
## Summary
- Implements SAQ type selection UI to leverage backend SAQ type differentiation for improved grading accuracy
- Adds dropdown menu with user-friendly labels (Source Analysis, Content Question, Historical Comparison)
- Maintains backward compatibility with existing SAQ submissions

## Changes Made
- Added SAQType enum with proper backend value mapping
- Created SAQTypeSelector component with conditional display (SAQ essays only)
- Updated GradingRequest model to include optional saq_type parameter
- Integrated SAQ type selection into ContentView with state management
- Added state reset logic when essay type changes
- Updated NetworkService to pass saq_type parameter to backend API

## Test Plan
- [x] Frontend builds and displays SAQ type selector only for SAQ essays
- [x] Backend correctly receives and validates saq_type parameter
- [x] SAQ grading works with type selection (tested with stimulus type)
- [x] Backward compatibility verified - SAQ submissions work without type selection
- [x] Validation works - saq_type properly rejected for DBQ/LEQ essays
- [x] State management handles essay type changes correctly

## Benefits
- Improved grading accuracy through type-specific AI prompts
- Better user experience with clear SAQ type selection
- Enhanced feedback quality for different SAQ question types

🤖 Generated with [Claude Code](https://claude.ai/code)