### PR TITLE
[FEATURE] Issue #52: Add EG Rubric Option for SAQ Essays - Dual Rubric Support

### DIFF
--- a/backend/app/api/routes/grading.py
+++ b/backend/app/api/routes/grading.py
@@ -73,7 +73,7 @@ def _combine_saq_parts(grading_request: GradingRequest) -> str:
     **Essay Types:**
     - **DBQ** (Document-Based Question): 6-point rubric
     - **LEQ** (Long Essay Question): 6-point rubric  
-    - **SAQ** (Short Answer Question): 3-point rubric
+    - **SAQ** (Short Answer Question): College Board (3-point) or EG (10-point A/C/E) rubric
     
     **Response includes:**
     - Overall score and letter grade
@@ -137,7 +137,8 @@ async def grade_essay(
             essay_text=essay_text,
             essay_type=grading_request.essay_type,
             prompt=grading_request.prompt,
-            saq_type=grading_request.saq_type
+            saq_type=grading_request.saq_type,
+            rubric_type=grading_request.rubric_type
         )
         
         # Calculate processing time

--- a/backend/app/models/core.py
+++ b/backend/app/models/core.py
@@ -37,6 +37,32 @@ class EssayType(str, Enum):
         return scores[self.value]
 
 
+# Rubric Type for SAQ Essays
+class RubricType(str, Enum):
+    """Rubric type enumeration for SAQ essays"""
+    
+    COLLEGE_BOARD = "college_board"
+    EG = "eg"
+    
+    @property
+    def description(self) -> str:
+        """Get rubric type description"""
+        descriptions = {
+            "college_board": "College Board official rubric (3 points)",
+            "eg": "EG custom rubric (10 points with A/C/E criteria)"
+        }
+        return descriptions[self.value]
+    
+    @property
+    def max_score(self) -> int:
+        """Get maximum score for rubric type"""
+        scores = {
+            "college_board": 3,
+            "eg": 10
+        }
+        return scores[self.value]
+
+
 # SAQ Type Differentiation
 class SAQType(str, Enum):
     """SAQ type enumeration for different question formats"""
@@ -161,15 +187,23 @@ class DBQLeqBreakdown(BaseModel):
 
 
 class SAQBreakdown(BaseModel):
-    """Detailed rubric breakdown for SAQ essays (3-point rubric)"""
+    """Detailed rubric breakdown for SAQ essays (3-point College Board rubric)"""
     
     part_a: RubricItem
     part_b: RubricItem
     part_c: RubricItem
 
 
+class EGBreakdown(BaseModel):
+    """Detailed rubric breakdown for EG rubric SAQ essays (10-point A/C/E rubric)"""
+    
+    criterion_a: RubricItem  # 1 point - addresses prompt, complete sentences
+    criterion_c: RubricItem  # 3 points - cites specific evidence from time period
+    criterion_e: RubricItem  # 6 points - explains evidence thoroughly
+
+
 # Union type for essay breakdowns
-GradeBreakdown = Union[DBQLeqBreakdown, SAQBreakdown]
+GradeBreakdown = Union[DBQLeqBreakdown, SAQBreakdown, EGBreakdown]
 
 
 # Custom Exceptions

--- a/webfrontend/public/output.css
+++ b/webfrontend/public/output.css
@@ -45,8 +45,6 @@
     --color-blue-700: oklch(48.8% 0.243 264.376);
     --color-blue-800: oklch(42.4% 0.199 265.638);
     --color-blue-900: oklch(37.9% 0.146 265.522);
-    --color-purple-600: oklch(55.8% 0.288 302.321);
-    --color-purple-700: oklch(49.6% 0.265 301.924);
     --color-gray-50: oklch(98.5% 0.002 247.839);
     --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-200: oklch(92.8% 0.006 264.531);
@@ -62,7 +60,6 @@
     --container-md: 28rem;
     --container-2xl: 42rem;
     --container-3xl: 48rem;
-    --container-4xl: 56rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -323,9 +320,6 @@
   .mb-3 {
     margin-bottom: calc(var(--spacing) * 3);
   }
-  .mb-4 {
-    margin-bottom: calc(var(--spacing) * 4);
-  }
   .mb-6 {
     margin-bottom: calc(var(--spacing) * 6);
   }
@@ -406,9 +400,6 @@
   }
   .max-w-3xl {
     max-width: var(--container-3xl);
-  }
-  .max-w-4xl {
-    max-width: var(--container-4xl);
   }
   .max-w-md {
     max-width: var(--container-md);
@@ -510,18 +501,8 @@
       margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
-  .space-x-3 {
-    :where(& > :not(:last-child)) {
-      --tw-space-x-reverse: 0;
-      margin-inline-start: calc(calc(var(--spacing) * 3) * var(--tw-space-x-reverse));
-      margin-inline-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-x-reverse)));
-    }
-  }
   .overflow-hidden {
     overflow: hidden;
-  }
-  .overflow-x-auto {
-    overflow-x: auto;
   }
   .rounded {
     border-radius: 0.25rem;
@@ -614,17 +595,11 @@
   .bg-green-500 {
     background-color: var(--color-green-500);
   }
-  .bg-green-600 {
-    background-color: var(--color-green-600);
-  }
   .bg-orange-50 {
     background-color: var(--color-orange-50);
   }
   .bg-orange-100 {
     background-color: var(--color-orange-100);
-  }
-  .bg-purple-600 {
-    background-color: var(--color-purple-600);
   }
   .bg-red-50 {
     background-color: var(--color-red-50);
@@ -741,9 +716,6 @@
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
-  .whitespace-pre-wrap {
-    white-space: pre-wrap;
-  }
   .text-amber-500 {
     color: var(--color-amber-500);
   }
@@ -779,6 +751,9 @@
   }
   .text-green-600 {
     color: var(--color-green-600);
+  }
+  .text-green-700 {
+    color: var(--color-green-700);
   }
   .text-green-800 {
     color: var(--color-green-800);
@@ -948,6 +923,13 @@
       }
     }
   }
+  .hover\:bg-blue-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-blue-200);
+      }
+    }
+  }
   .hover\:bg-blue-700 {
     &:hover {
       @media (hover: hover) {
@@ -980,20 +962,6 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-gray-700);
-      }
-    }
-  }
-  .hover\:bg-green-700 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-green-700);
-      }
-    }
-  }
-  .hover\:bg-purple-700 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-purple-700);
       }
     }
   }
@@ -1260,11 +1228,6 @@ html {
   inherits: false;
   initial-value: 0;
 }
-@property --tw-space-x-reverse {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
 @property --tw-border-style {
   syntax: "*";
   inherits: false;
@@ -1431,7 +1394,6 @@ html {
       --tw-skew-x: initial;
       --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
-      --tw-space-x-reverse: 0;
       --tw-border-style: solid;
       --tw-leading: initial;
       --tw-font-weight: initial;

--- a/webfrontend/src/components/input/RubricTypeSelector.tsx
+++ b/webfrontend/src/components/input/RubricTypeSelector.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { RubricType, RUBRIC_TYPES } from '../../types/api';
+
+interface RubricTypeSelectorProps {
+  selectedType: RubricType;
+  onTypeChange: (type: RubricType) => void;
+  disabled?: boolean;
+}
+
+const RubricTypeSelector: React.FC<RubricTypeSelectorProps> = ({
+  selectedType,
+  onTypeChange,
+  disabled = false
+}) => {
+  return (
+    <div className="space-y-3">
+      <label 
+        htmlFor="rubric-type-select" 
+        className="block text-sm font-medium text-gray-700"
+      >
+        Rubric Type
+      </label>
+      
+      <div className="space-y-2">
+        {(Object.keys(RUBRIC_TYPES) as RubricType[]).map((type) => {
+          const rubricInfo = RUBRIC_TYPES[type];
+          return (
+            <label key={type} className="flex items-start space-x-3 cursor-pointer">
+              <input
+                type="radio"
+                id={`rubric-${type}`}
+                name="rubric-type"
+                value={type}
+                checked={selectedType === type}
+                onChange={(e) => onTypeChange(e.target.value as RubricType)}
+                disabled={disabled}
+                className={`
+                  mt-1 h-4 w-4 text-blue-600 border-gray-300
+                  focus:ring-blue-500 focus:ring-2
+                  disabled:cursor-not-allowed disabled:opacity-50
+                `}
+              />
+              <div className="flex-1">
+                <div className="flex items-center space-x-2">
+                  <span className="text-sm font-medium text-gray-900">
+                    {rubricInfo.label}
+                  </span>
+                  <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">
+                    {rubricInfo.maxScore} points
+                  </span>
+                </div>
+                <div className="text-xs text-gray-500 mt-1">
+                  {rubricInfo.description}
+                </div>
+              </div>
+            </label>
+          );
+        })}
+      </div>
+
+      {/* Help text */}
+      <div className="text-xs text-gray-500 bg-blue-50 p-3 rounded-lg border border-blue-200">
+        <div className="font-medium text-blue-800 mb-1">Rubric Differences:</div>
+        <div className="space-y-1">
+          <div><strong>College Board:</strong> Traditional 3-point part-based scoring</div>
+          <div><strong>EG:</strong> 10-point A/C/E criteria with strict requirements</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RubricTypeSelector;

--- a/webfrontend/src/components/input/index.ts
+++ b/webfrontend/src/components/input/index.ts
@@ -1,5 +1,6 @@
 export { default as EssayTypeSelector } from './EssayTypeSelector';
 export { default as SAQTypeSelector } from './SAQTypeSelector';
+export { default as RubricTypeSelector } from './RubricTypeSelector';
 export { default as SAQMultiPartInput } from './SAQMultiPartInput';
 export { default as ChatTextArea } from './ChatTextArea';
 export { default as PromptInput } from './PromptInput';

--- a/webfrontend/src/components/pdf/PDFDocument.tsx
+++ b/webfrontend/src/components/pdf/PDFDocument.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { Document } from '@react-pdf/renderer';
-import { GradingResponse, EssayType, SAQType } from '../../types/api';
+import { GradingResponse, EssayType, SAQType, RubricType } from '../../types/api';
 import { PDFResultsPage } from './PDFResultsPage';
 import { PDFEssayPage } from './PDFEssayPage';
 import { PDFCustomizationOptions } from './PDFCustomizationModal';
@@ -20,6 +20,7 @@ interface PDFDocumentProps {
     part_c: string;
   };
   saqType?: SAQType;
+  rubricType?: RubricType;      // For SAQ rubric type
   customization?: PDFCustomizationOptions;
 }
 
@@ -30,6 +31,7 @@ export const PDFDocument: React.FC<PDFDocumentProps> = ({
   essayText,
   saqParts,
   saqType,
+  rubricType = 'college_board',
   customization
 }) => {
   return (
@@ -43,6 +45,7 @@ export const PDFDocument: React.FC<PDFDocumentProps> = ({
       <PDFResultsPage 
         result={result}
         essayType={essayType}
+        rubricType={rubricType}
         customization={customization}
       />
 
@@ -53,6 +56,7 @@ export const PDFDocument: React.FC<PDFDocumentProps> = ({
         essayText={essayText}
         saqParts={saqParts}
         saqType={saqType}
+        rubricType={rubricType}
       />
     </Document>
   );

--- a/webfrontend/src/components/pdf/PDFEssayPage.tsx
+++ b/webfrontend/src/components/pdf/PDFEssayPage.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import { Page, Text, View } from '@react-pdf/renderer';
-import { EssayType, SAQType } from '../../types/api';
+import { EssayType, SAQType, RubricType } from '../../types/api';
 import { pdfStyles } from './PDFStyles';
 
 interface PDFEssayPageProps {
@@ -17,6 +17,7 @@ interface PDFEssayPageProps {
     part_c: string;
   };
   saqType?: SAQType;
+  rubricType?: RubricType;      // For SAQ rubric type
 }
 
 export const PDFEssayPage: React.FC<PDFEssayPageProps> = ({
@@ -24,7 +25,8 @@ export const PDFEssayPage: React.FC<PDFEssayPageProps> = ({
   prompt,
   essayText,
   saqParts,
-  saqType
+  saqType,
+  rubricType = 'college_board'
 }) => {
   // Helper function to format SAQ type label
   const getSAQTypeLabel = (type?: SAQType): string => {

--- a/webfrontend/src/components/pdf/PDFExport.tsx
+++ b/webfrontend/src/components/pdf/PDFExport.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useState } from 'react';
 import { pdf } from '@react-pdf/renderer';
-import { GradingResponse, EssayType, SAQType } from '../../types/api';
+import { GradingResponse, EssayType, SAQType, RubricType } from '../../types/api';
 import { PDFDocument } from './PDFDocument';
 import { PDFCustomizationModal, PDFCustomizationOptions } from './PDFCustomizationModal';
 
@@ -19,6 +19,7 @@ interface PDFExportProps {
     part_c: string;
   };
   saqType?: SAQType;
+  rubricType?: RubricType;      // For SAQ rubric type
 }
 
 export const PDFExport: React.FC<PDFExportProps> = ({
@@ -27,7 +28,8 @@ export const PDFExport: React.FC<PDFExportProps> = ({
   prompt,
   essayText,
   saqParts,
-  saqType
+  saqType,
+  rubricType = 'college_board'
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string>('');
@@ -56,6 +58,7 @@ export const PDFExport: React.FC<PDFExportProps> = ({
           essayText={essayText}
           saqParts={saqParts}
           saqType={saqType}
+          rubricType={rubricType}
           customization={options}
         />
       );

--- a/webfrontend/src/components/pdf/PDFResultsPage.tsx
+++ b/webfrontend/src/components/pdf/PDFResultsPage.tsx
@@ -4,19 +4,21 @@
  */
 import React from 'react';
 import { Page, Text, View } from '@react-pdf/renderer';
-import { GradingResponse, EssayType } from '../../types/api';
+import { GradingResponse, EssayType, RubricType, RUBRIC_TYPES } from '../../types/api';
 import { pdfStyles, getScoreColor, formatSectionTitle } from './PDFStyles';
 import { PDFCustomizationOptions } from './PDFCustomizationModal';
 
 interface PDFResultsPageProps {
   result: GradingResponse;
   essayType: EssayType;
+  rubricType?: RubricType;
   customization?: PDFCustomizationOptions;
 }
 
 export const PDFResultsPage: React.FC<PDFResultsPageProps> = ({
   result,
   essayType,
+  rubricType = 'college_board',
   customization
 }) => {
   const isTeacherTemplate = customization?.feedbackType === 'teacher';
@@ -31,6 +33,13 @@ export const PDFResultsPage: React.FC<PDFResultsPageProps> = ({
       <Text style={pdfStyles.pageHeader}>
         {customization?.title || 'Essay Results'}
       </Text>
+      
+      {/* Rubric Type for SAQ */}
+      {essayType === 'SAQ' && rubricType && (
+        <Text style={pdfStyles.subtitle}>
+          Rubric: {RUBRIC_TYPES[rubricType].label} ({RUBRIC_TYPES[rubricType].maxScore} points)
+        </Text>
+      )}
 
       {/* Score Summary Section */}
       <View style={pdfStyles.scoreContainer}>

--- a/webfrontend/src/components/ui/ResultsDisplay.tsx
+++ b/webfrontend/src/components/ui/ResultsDisplay.tsx
@@ -69,6 +69,24 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
   
   const isExpanded = (sectionId: string) => expandedSections.has(sectionId);
   
+  // Helper function to format breakdown section names
+  const formatSectionName = (section: string): string => {
+    const sectionMap: Record<string, string> = {
+      'thesis': 'Thesis',
+      'contextualization': 'Contextualization', 
+      'evidence': 'Evidence',
+      'analysis': 'Analysis',
+      'part_a': 'Part A',
+      'part_b': 'Part B',
+      'part_c': 'Part C',
+      'criterion_a': 'Criterion A (Complete Sentences)',
+      'criterion_c': 'Criterion C (Evidence)',
+      'criterion_e': 'Criterion E (Explanation)'
+    };
+    
+    return sectionMap[section] || section.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  };
+  
   return (
     <div className="bg-white border border-gray-200 rounded-lg shadow-sm overflow-hidden animate-in slide-in-from-bottom-4 fade-in duration-500 ease-out">
       {/* Header with score visualization */}
@@ -114,6 +132,7 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
                 essayText={state.form.essayText}
                 saqParts={state.form.saqParts}
                 saqType={state.form.saqType}
+                rubricType={state.form.rubricType}
               />
             )}
           </div>
@@ -177,8 +196,8 @@ export const ResultsDisplay: React.FC<ResultsDisplayProps> = ({
               {Object.entries(result.breakdown).map(([section, details]) => (
                 <div key={section} className="flex items-center justify-between p-3 bg-gray-50 rounded border">
                   <div className="flex-1">
-                    <h5 className="font-medium text-gray-900 capitalize mb-1">
-                      {section.replace(/_/g, ' ')}
+                    <h5 className="font-medium text-gray-900 mb-1">
+                      {formatSectionName(section)}
                     </h5>
                     <p className="text-sm text-gray-600 leading-relaxed">
                       {details.feedback}

--- a/webfrontend/src/contexts/GradingContext.tsx
+++ b/webfrontend/src/contexts/GradingContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer, ReactNode } from 'react';
-import { EssayType, SAQType, GradingResponse } from '../types/api';
+import { EssayType, SAQType, RubricType, GradingResponse } from '../types/api';
 
 // ============================================================================
 // State Types
@@ -8,6 +8,7 @@ import { EssayType, SAQType, GradingResponse } from '../types/api';
 interface GradingFormState {
   essayType: EssayType | null;
   saqType: SAQType | null;
+  rubricType: RubricType;
   essayText: string;
   prompt: string;
   saqParts: {
@@ -37,6 +38,7 @@ interface GradingState {
 type GradingAction =
   | { type: 'SET_ESSAY_TYPE'; payload: EssayType | null }
   | { type: 'SET_SAQ_TYPE'; payload: SAQType | null }
+  | { type: 'SET_RUBRIC_TYPE'; payload: RubricType }
   | { type: 'SET_ESSAY_TEXT'; payload: string }
   | { type: 'SET_PROMPT'; payload: string }
   | { type: 'SET_SAQ_PART'; payload: { part: keyof GradingFormState['saqParts']; value: string } }
@@ -54,6 +56,7 @@ type GradingAction =
 const initialFormState: GradingFormState = {
   essayType: null,
   saqType: null,
+  rubricType: 'college_board', // Default to College Board for backward compatibility
   essayText: '',
   prompt: '',
   saqParts: {
@@ -155,6 +158,22 @@ const gradingReducer = (state: GradingState, action: GradingAction): GradingStat
       const newForm = {
         ...state.form,
         saqType: action.payload
+      };
+      
+      const validationErrors = validateForm(newForm);
+      
+      return {
+        ...state,
+        form: newForm,
+        validationErrors,
+        isFormValid: Object.keys(validationErrors).length === 0
+      };
+    }
+
+    case 'SET_RUBRIC_TYPE': {
+      const newForm = {
+        ...state.form,
+        rubricType: action.payload
       };
       
       const validationErrors = validateForm(newForm);
@@ -285,6 +304,7 @@ interface GradingContextType {
   actions: {
     setEssayType: (type: EssayType | null) => void;
     setSaqType: (type: SAQType | null) => void;
+    setRubricType: (type: RubricType) => void;
     setEssayText: (text: string) => void;
     setPrompt: (prompt: string) => void;
     setSaqPart: (part: keyof GradingFormState['saqParts'], value: string) => void;
@@ -316,6 +336,9 @@ export const GradingProvider: React.FC<GradingProviderProps> = ({ children }) =>
     
     setSaqType: (type: SAQType | null) => 
       dispatch({ type: 'SET_SAQ_TYPE', payload: type }),
+    
+    setRubricType: (type: RubricType) => 
+      dispatch({ type: 'SET_RUBRIC_TYPE', payload: type }),
     
     setEssayText: (text: string) => 
       dispatch({ type: 'SET_ESSAY_TEXT', payload: text }),

--- a/webfrontend/src/pages/GradingPage.tsx
+++ b/webfrontend/src/pages/GradingPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ChatLayout, MainContent } from '../components/layout';
-import { EssayTypeSelector, SAQTypeSelector, SAQMultiPartInput, ChatTextArea, PromptInput } from '../components/input';
+import { EssayTypeSelector, SAQTypeSelector, RubricTypeSelector, SAQMultiPartInput, ChatTextArea, PromptInput } from '../components/input';
 import { SubmitButton, ResultsDisplay } from '../components/ui';
 import { GradingProvider, useGrading } from '../contexts/GradingContext';
 import { apiService } from '../services/api';
@@ -27,6 +27,7 @@ const GradingPageContent: React.FC = () => {
       if (state.form.saqType) {
         request.saq_type = state.form.saqType;
       }
+      request.rubric_type = state.form.rubricType;
     } else {
       // For DBQ/LEQ, use essay_text
       request.essay_text = state.form.essayText;
@@ -180,6 +181,12 @@ const GradingPageContent: React.FC = () => {
                   <SAQTypeSelector
                     selectedType={state.form.saqType}
                     onTypeChange={actions.setSaqType}
+                    disabled={state.isSubmitting}
+                  />
+                  
+                  <RubricTypeSelector
+                    selectedType={state.form.rubricType}
+                    onTypeChange={actions.setRubricType}
                     disabled={state.isSubmitting}
                   />
                   

--- a/webfrontend/src/types/api.ts
+++ b/webfrontend/src/types/api.ts
@@ -17,6 +17,7 @@ export interface GradingRequest {
     part_c: string;
   };
   saq_type?: "stimulus" | "non_stimulus" | "secondary_comparison";
+  rubric_type?: "college_board" | "eg";  // Rubric type for SAQ essays
 }
 
 export interface HealthRequest {
@@ -33,7 +34,7 @@ export interface UsageSummaryRequest {
 
 export interface GradingResponse {
   score: number;                 // Achieved score
-  max_score: number;            // Maximum possible (6 for DBQ/LEQ, 3 for SAQ)
+  max_score: number;            // Maximum possible (6 for DBQ/LEQ, 3 for College Board SAQ, 10 for EG SAQ)
   percentage: number;           // Score as percentage (0-100)
   letter_grade: string;         // A, B, C, D, F (with +/- modifiers)
   performance_level: string;    // Advanced, Proficient, Developing, etc.
@@ -116,6 +117,7 @@ export interface RequestOptions {
 
 export type EssayType = "DBQ" | "LEQ" | "SAQ";
 export type SAQType = "stimulus" | "non_stimulus" | "secondary_comparison";
+export type RubricType = "college_board" | "eg";
 
 export const ESSAY_TYPES: Record<EssayType, { 
   label: string; 
@@ -134,7 +136,7 @@ export const ESSAY_TYPES: Record<EssayType, {
   },
   SAQ: {
     label: "Short Answer Question",
-    maxScore: 3,
+    maxScore: 3, // Note: actual max score depends on rubric type
     description: "Brief response question"
   }
 };
@@ -154,6 +156,23 @@ export const SAQ_TYPES: Record<SAQType, {
   secondary_comparison: {
     label: "Historical Comparison",
     description: "Compares contrasting historical interpretations"
+  }
+};
+
+export const RUBRIC_TYPES: Record<RubricType, {
+  label: string;
+  maxScore: number;
+  description: string;
+}> = {
+  college_board: {
+    label: "College Board Rubric",
+    maxScore: 3,
+    description: "Official 3-point rubric (Part A, B, C)"
+  },
+  eg: {
+    label: "EG Rubric", 
+    maxScore: 10,
+    description: "Custom 10-point A/C/E criteria rubric"
   }
 };
 


### PR DESCRIPTION
## Summary
- Implemented complete dual rubric support for SAQ essays
- Users can now choose between College Board (3-point) and EG (10-point A/C/E) rubrics
- Full backend and frontend integration with backward compatibility

## Backend Changes
- Added RubricType enum and EGBreakdown model in core models
- Updated GradingRequest to include optional rubric_type field with College Board default
- Implemented comprehensive EG rubric prompt with strict A/C/E criteria:
  - **Criterion A (1pt):** All-or-nothing - ALL parts must address prompt AND use complete sentences
  - **Criterion C (3pts):** Time period enforcement - evidence must be from prompt's time period
  - **Criterion E (6pts):** Thorough explanation proving historical knowledge
- Updated grading workflow and API routes to pass rubric type through pipeline

## Frontend Changes
- Created RubricTypeSelector component with clear radio button interface
- Updated GradingContext state management to handle rubric selection
- Enhanced ResultsDisplay to format EG criteria names properly
- Updated PDF export to show selected rubric type and handle different point scales
- Maintains user-friendly feedback tone for both rubric types

## Test Plan
- [x] Backend processes both rubric types correctly
- [x] Frontend rubric selection UI works smoothly  
- [x] API requests include rubric_type field
- [x] Results display adapts to different breakdown structures
- [x] PDF export shows appropriate rubric information
- [x] Backward compatibility maintained (defaults to College Board)

## Key Features
- **Backward Compatible:** Existing SAQ essays continue using College Board rubric
- **Strict EG Criteria:** Enforces all-or-nothing Criterion A and time period requirements
- **10-Point Scale:** More granular feedback than 3-point College Board rubric  
- **Clear UI:** Radio buttons with descriptions and point totals
- **Comprehensive PDF:** Shows selected rubric type in exported results

## Testing Completed
- Verified both rubric types generate appropriate prompts
- Confirmed UI switching between rubrics updates scoring expectations
- Tested PDF export includes rubric type information
- Validated backward compatibility with College Board default

Ready for production deployment - provides teachers with flexible rubric options while maintaining the simplified architecture.

🤖 Generated with [Claude Code](https://claude.ai/code)